### PR TITLE
Feat explicit UUID mysql

### DIFF
--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -117,6 +117,9 @@ func (s *mysql) DataTypeOf(field *StructField) string {
 				}
 			}
 		}
+	} else if isUUID(dataValue) {
+		// In case the user has specified uuid as the type explicitly
+		sqlType = "varchar(36)"
 	}
 
 	if sqlType == "" {

--- a/dialect_mysql.go
+++ b/dialect_mysql.go
@@ -110,7 +110,10 @@ func (s *mysql) DataTypeOf(field *StructField) string {
 			}
 		default:
 			if IsByteArrayOrSlice(dataValue) {
-				if size > 0 && size < 65532 {
+				if isJSON(dataValue) {
+					// Adding a constraint to see ensure that the value is a well formed JSON
+					sqlType = "json"
+				} else if size > 0 && size < 65532 {
 					sqlType = fmt.Sprintf("varbinary(%d)", size)
 				} else {
 					sqlType = "longblob"


### PR DESCRIPTION
* In case SQL type is UUID, set the mysql column type as `varchar(36)`
* In case the struct field is of the type json.RawMessage, set the MySQL type to `json`