### PR TITLE
Fix float64 oracle overflow

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -177,6 +177,12 @@ func afterCreateCallback(scope *Scope) {
 		scope.Dialect().SetDB(scope.db.db)
 		primaryField := scope.PrimaryField()
 		val := primaryField.Field.Interface()
+
+		// In case the primary key implements valuer, using the value from that valuer to resolve a row ID
+		if primary, ok := val.(primary); ok {
+			val = primary.ID
+		}
+
 		// Row ID cannot be 0. Obvious issue that has occurred upstream.
 		if arg, ok := val.(uint); ok && arg != 0{
 			scope.Err(primaryField.Set(scope.Dialect().ResolveRowID(scope.TableName(), arg)))

--- a/dialect_oci8.go
+++ b/dialect_oci8.go
@@ -154,7 +154,7 @@ func (o *oci8) ResolveRowID(tableName string, rowID uint) uint{
 	query := fmt.Sprintf(`SELECT id FROM %s WHERE rowid = :2`, o.Quote(tableName))
 	var err error
 	if err = o.db.QueryRow(query, strRowID).Scan(&id); err == nil{
-		if res, err := strconv.ParseUint(id, 10, 32); err == nil{
+		if res, err := strconv.ParseUint(id, 10, 64); err == nil{
 			resolvedId := uint(res)
 			return resolvedId
 		}

--- a/model.go
+++ b/model.go
@@ -1,6 +1,9 @@
 package gorm
 
-import "time"
+import (
+	"database/sql/driver"
+	"time"
+)
 
 // Model base model definition, including fields `ID`, `CreatedAt`, `UpdatedAt`, `DeletedAt`, which could be embedded in your models
 //    type User struct {
@@ -8,6 +11,38 @@ import "time"
 //    }
 type Model struct {
 	ID        uint `gorm:"primary_key"`
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time `sql:"index"`
+}
+
+type primary struct {
+	ID uint
+}
+
+func (x *primary) Scan(src interface{}) error {
+	if val, ok := src.(uint); ok {
+		x.ID = val
+	} else if val, ok := src.(float64); ok {
+		// This happens due to oracle driver not knowing that uint is required by the calling code.
+		x.ID = uint(val)
+	} else if val, ok := src.(int64); ok {
+		x.ID = uint(val)
+	}
+	// Note: This else results in errors while inserting into the table in oracle. Hence not using such a clause
+	//else {
+	//	return errors.New(fmt.Sprintf("Unable to convert %v to uint", src))
+	//}
+
+	return nil
+}
+
+func (x *primary) Value() (driver.Value, error) {
+	return x.ID, nil
+}
+
+type ORM struct {
+	ID        primary `gorm:"primary_key"`
 	CreatedAt time.Time
 	UpdatedAt time.Time
 	DeletedAt *time.Time `sql:"index"`


### PR DESCRIPTION
* The oracle driver returns `float64` when the no. of rows goes beyond 1000000.
* When using `gorm.Model`, this results in an error when reading from a table with this many rows.
* Introducing `gorm.ORM` which will mitigate this issue and work for all databases by adapting the driver results.
* This is achieved by implementing the `sql.Scanner` interface from the `database/sql` package.
* The ID is encapsulated as a `uint` in the primary struct.
