### PR TITLE
refactor: Remove primary key and foreign key custom structs

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -178,11 +178,6 @@ func afterCreateCallback(scope *Scope) {
 		primaryField := scope.PrimaryField()
 		val := primaryField.Field.Interface()
 
-		// In case the Primary key is of type gorm.Primary, using the value from that valuer to resolve a row ID
-		if primary, ok := val.(Primary); ok {
-			val = primary.ID
-		}
-
 		// Row ID cannot be 0. Obvious issue that has occurred upstream.
 		if arg, ok := val.(uint); ok && arg != 0{
 			scope.Err(primaryField.Set(scope.Dialect().ResolveRowID(scope.TableName(), arg)))

--- a/model.go
+++ b/model.go
@@ -1,7 +1,6 @@
 package gorm
 
 import (
-	"database/sql/driver"
 	"time"
 )
 
@@ -16,34 +15,3 @@ type Model struct {
 	DeletedAt *time.Time `sql:"index"`
 }
 
-type Primary struct {
-	ID uint
-}
-
-func (x *Primary) Scan(src interface{}) error {
-	if val, ok := src.(uint); ok {
-		x.ID = val
-	} else if val, ok := src.(float64); ok {
-		// This happens due to oracle driver not knowing that uint is required by the calling code.
-		x.ID = uint(val)
-	} else if val, ok := src.(int64); ok {
-		x.ID = uint(val)
-	}
-	// Note: This else results in errors while inserting into the table in oracle. Hence not using such a clause
-	//else {
-	//	return errors.New(fmt.Sprintf("Unable to convert %v to uint", src))
-	//}
-
-	return nil
-}
-
-func (x *Primary) Value() (driver.Value, error) {
-	return x.ID, nil
-}
-
-type ORM struct {
-	ID        Primary `gorm:"primary_key"`
-	CreatedAt time.Time
-	UpdatedAt time.Time
-	DeletedAt *time.Time `sql:"index"`
-}


### PR DESCRIPTION
Removing `gorm.Primary`.
Moving this to `vcore.vorm`.