### PR TITLE
add: Method to increment integer attrs for a table's row

### DIFF
--- a/main.go
+++ b/main.go
@@ -438,6 +438,15 @@ func (s *DB) Update(attrs ...interface{}) *DB {
 	return s.Updates(toSearchableMap(attrs...), true)
 }
 
+// Increments integer attributes with the values set in the interface passed
+func (s *DB) Increment(values interface{}, ignoreProtectedAttrs ...bool) *DB {
+	return s.NewScope(values).
+		Set("gorm:ignore_protected_attrs", len(ignoreProtectedAttrs) > 0).
+		InstanceSet("gorm:update_interface", values).
+		InstanceSet("gorm:increment_attrs", values).
+		callCallbacks(s.parent.callbacks.updates).db
+}
+
 // Updates update attributes with callbacks, refer: https://jinzhu.github.io/gorm/crud.html#update
 func (s *DB) Updates(values interface{}, ignoreProtectedAttrs ...bool) *DB {
 	return s.NewScope(s.Value).


### PR DESCRIPTION
### What did this pull request do?

Added a method to increment integer columns for a given table's row.

This will make use of the statement `UPDATE <table> SET attr = attr + increment` to dynamically increment all the integer columns corresponding to a struct passed.

eg.
```
query.Increment(
&Aggregates{Id: 1, total: 23, repeated: 11}
)
```

This will result in the query:
```
UPDATE aggregates SET total = total + 23, repeated = repeated + 11 WHERE id=1;
```