### PR TITLE
[AN-62] Custom tags for column types

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -154,6 +154,10 @@ var ParseFieldStructForDialect = func(field *StructField, dialect Dialect) (fiel
 		additionalType = additionalType + " COMMENT " + value
 	}
 
+	if value, ok := dialect.GetTagSetting(field, "CUSTOM"); ok {
+		additionalType = additionalType + value
+	}
+
 	return fieldValue, dataType, size, strings.TrimSpace(additionalType)
 }
 

--- a/dialect_postgres.go
+++ b/dialect_postgres.go
@@ -152,3 +152,12 @@ func isJSON(value reflect.Value) bool {
 	_, ok := value.Interface().(json.RawMessage)
 	return ok
 }
+
+// Check if there is a dialect specific setting first, if yes, that takes precedence
+// Dialect specific keys can be specified by prefixing the dialect name to the key.
+// eg. A dialect specific size for postgres can be specified as "postgres size"
+// Then check if there is a generic setting
+func (s postgres) GetTagSetting(field *StructField, key string) (val string, ok bool) {
+	val, ok = field.TagSettingsGetFirst(strings.ToUpper(s.GetName())+" "+key, key)
+	return
+}


### PR DESCRIPTION
## Allow standalone tags to be added for columns

This can be done by making use of the `CUSTOM` tag as shown below.

```
type User struct {
    *gorm.Model
    Name string
}

type Address struct {
    *gorm.Model
    UserID             uint `sql:"type:int REFERENCES users(id)" gorm:"postgres default:null;oci8 custom:null"`
    Addr               string
}
```
This `custom` tag specific to the `oci8` dialect will allow the value of the `oci8 custom` tag to be appended to the column type of the `UserID` column being created.

The Oracle SQL generated for this:

```
CREATE TABLE "ADDRESS" (
    "ID" NUMBER GENERATED ALWAYS AS IDENTITY,
    "CREATED_AT" TIMESTAMP,"UPDATED_AT" TIMESTAMP,
    "DELETED_AT" TIMESTAMP,
    "USER_ID" int REFERENCES users(id) null,
    "ADDR" VARCHAR2(255), 
    PRIMARY KEY ("ID")
)
```

The PostgreSQL generated for this:

```
CREATE TABLE "ADDRESS" (
    "id" serial,"created_at" timestamp with time zone,
    "updated_at" timestamp with time zone,
    "deleted_at" timestamp with time zone,
    "user_id" int REFERENCES users(id) DEFAULT null,
    "addr" text, 
    PRIMARY KEY ("id")
)
```

Hence, this allows us to declare nullable columns across dialects.

The `postgres` specific tags are enabled by adding support for postgres specific tags.