### PR TITLE
[AN-62] Fix oci8 timestamp equality

### DIFF
--- a/dialect.go
+++ b/dialect.go
@@ -74,6 +74,8 @@ type Dialect interface {
 	GetTagSetting(field *StructField, key string) (string, bool)
 	// Determine the limit of byte size for a BLOB
 	GetByteLimit() int
+	// Formats the field in a way that the underlying DB is able parse it without issue
+	ConditionFormat(field *Field) (interface{}, bool)
 }
 
 var dialectsMap = map[string]Dialect{}

--- a/dialect_common.go
+++ b/dialect_common.go
@@ -221,3 +221,7 @@ func (s commonDialect) GetTagSetting(field *StructField, key string) (val string
 func (s commonDialect) GetByteLimit() int {
 	return -1
 }
+
+func (s commonDialect) ConditionFormat(field *Field) (interface{}, bool) {
+	return field.Field.Interface(), false
+}

--- a/dialect_oci8.go
+++ b/dialect_oci8.go
@@ -229,3 +229,16 @@ func (o *oci8) GetTagSetting(field *StructField, key string) (val string, ok boo
 func (o *oci8) GetByteLimit() int {
 	return 30000
 }
+
+func (o *oci8) ConditionFormat(field *Field) (interface{}, bool) {
+	if field.Field.Type() == reflect.TypeOf(time.Time{}) {
+		// Format timestamp for Oracle
+		//2018-11-03 12:35:20.419000
+		if t, ok := field.Field.Interface().(time.Time); ok  {
+			//return fmt.Sprintf("to_timestamp('%s', 'YYYY-MM-DD HH24:MI:SS.FF')", t.Format("2006-01-02 15:04:05.999999999")), true
+			return fmt.Sprintf("TIMESTAMP '%s'", t.Format("2006-01-02 15:04:05.999999999")), true
+		}
+	}
+
+	return o.commonDialect.ConditionFormat(field)
+}

--- a/dialect_oci8.go
+++ b/dialect_oci8.go
@@ -201,15 +201,15 @@ func (*oci8) LimitAndOffsetSQL(limit, offset interface{}) (sql string) {
 
 	// Offset clause comes first
 	if errOffsetParse == nil && parsedOffset >= 0 {
-		sql += fmt.Sprintf(" OFFSET %d", parsedOffset)
+		sql += fmt.Sprintf(" OFFSET %d ROWS", parsedOffset)
 	} else if parsedLimit > 0 {
 		// Set the offset as zero in case there is no offset > 0 specified for a limit > 0
-		sql += fmt.Sprintf(" OFFSET %d", 0)
+		sql += fmt.Sprintf(" OFFSET %d ROWS", 0)
 	}
 
 	// Limit clause comes later
 	if errLimitParse == nil && parsedLimit >= 0 {
-		sql += fmt.Sprintf(" ROWS FETCH NEXT %d ROWS ONLY", parsedLimit)
+		sql += fmt.Sprintf(" FETCH NEXT %d ROWS ONLY", parsedLimit)
 	}
 	return
 }

--- a/dialect_oci8.go
+++ b/dialect_oci8.go
@@ -86,7 +86,7 @@ func (o *oci8) SplitDataTypeOf(field *StructField) (string, string) {
 			}
 		case reflect.Struct:
 			if _, ok := dataValue.Interface().(time.Time); ok {
-				sqlType = "TIMESTAMP"
+				sqlType = "TIMESTAMP WITH TIME ZONE"
 			}
 		case reflect.Array, reflect.Slice:
 			if isUUID(dataValue) {


### PR DESCRIPTION
## Fixes:

1. Limit/Offset fix for the oci8 dialect
2. Fix `FirstOrCreate` behavior when using `time.Time` structs
3. While testing, realized that resolution of rowID for oci8 driver happens after resolution of `blank_columns_with_default_value` instance setting. Hence, moved the resolution of rowID to before this happens.
4.  For `time.Time` type, the column for the oci8 dialect will now be `TIMESTAMP WITH TIMEZONE`. It was earlier using `TIMESTAMP` only.
5. While testing, I also noticed panics when resolving rowID due to the `lastInsertID` not being the address of a pointer. Due to which, the `go-oci8` driver was panicking. For now, resolution is to recover from this panic and assume that the `lastInsertID` is the `ID` column of the row itself.
