### PR TITLE
[AN-129] fix: set foreignkey sql var as null when blank

### DIFF
--- a/callback_create.go
+++ b/callback_create.go
@@ -65,7 +65,11 @@ func createCallback(scope *Scope) {
 						scope.InstanceSet("gorm:blank_columns_with_default_value", blankColumnsWithDefaultValue)
 					} else if !field.IsPrimaryKey || !field.IsBlank {
 						columns = append(columns, scope.Quote(field.DBName))
-						placeholders = append(placeholders, scope.AddToVars(field.Field.Interface()))
+						if field.Struct.Type.String() == "vorm.Foreign" && isBlank(field.Field) {
+							placeholders = append(placeholders, scope.AddToVars(nil))
+						} else {
+							placeholders = append(placeholders, scope.AddToVars(field.Field.Interface()))
+						}
 					}
 				} else if field.Relationship != nil && field.Relationship.Kind == "belongs_to" {
 					for _, foreignKey := range field.Relationship.ForeignDBNames {


### PR DESCRIPTION
### What did this pull request do?
Gorm uses the default value for uint, ie `0`, in prepared statements while insertion if no foreign key is provided for a model. Doing so requires a primary key with value `0` to be present in the referenced table which is often not the case giving rise to errors.

This PR replaces this `0` with `NULL`, which should be the actual behaviour.
