### PR TITLE
fix: support logging db trace when using oracle by supporting its pre…

### DIFF
--- a/logger.go
+++ b/logger.go
@@ -14,7 +14,7 @@ import (
 
 var (
 	defaultLogger            = Logger{log.New(os.Stdout, "\r\n", 0)}
-	sqlRegexp                = regexp.MustCompile(`\?`)
+	sqlRegexp                = regexp.MustCompile(`\?|:\d`)
 	numericPlaceHolderRegexp = regexp.MustCompile(`\$\d+`)
 )
 


### PR DESCRIPTION
…pared param through regex

Make sure these boxes checked before submitting your pull request.

- [X] Do only one thing
- [X] No API-breaking changes
- [X] New code/logic commented & tested

For significant changes like big bug fixes, new features, please open an issue to make an agreement on an implementation design/plan first before starting it.

### What did this pull request do?
Support logging db trace when using oracle by supporting its prepared param through regex
currently it's like
```
INSERT  INTO "CALLS" ("CREATED_AT","UPDATED_AT","DELETED_AT","CLIENT_ID","FLOW_ID","UUID","CALLER_NUMBER","VIRTUAL_NUMBER","TYPE","FLOW_VERSION","HOUR_ID")
VALUES
(:1,:2,:3,:4,:5,:6,:7,:8,:9,:10,:11)'2022-04-20 14:33:40'
```

result
```
INSERT  INTO "CALLS" 
("CREATED_AT","UPDATED_AT","DELETED_AT","CLIENT_ID","FLOW_ID","UUID","CALLER_NUMBER","VIRTUAL_NUMBER","TYPE","FLOW_VERSION","HOUR_ID")
VALUES
('2022-04-20 14:39:33','2022-04-20 14:39:33',NULL,NULL,NULL,'12312313','123','asdad','','',NULL)
```

PS: manually added new lines to log examples to make it readable